### PR TITLE
Fix ES module imports

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 dotenv.config();
-import { IConfig } from "./interface";
+import { IConfig } from "./interface.js";
 
 export const config: IConfig = {
   api: process.env.API,

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,5 +1,5 @@
 import {ChatCompletionRequestMessage, ChatCompletionRequestMessageRoleEnum} from "openai";
-import {User} from "./interface";
+import {User} from "./interface.js";
 import {isTokenOverLimit} from "./utils.js";
 
 /**


### PR DESCRIPTION
## Summary
- fix imports in config and data modules

## Testing
- `npm run build` *(fails: Cannot find module 'openai' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683fb044a13c8330acf65518f7f290af